### PR TITLE
fix #4 where hovers didn't work

### DIFF
--- a/admin_menu/templates/admin/base_site.html
+++ b/admin_menu/templates/admin/base_site.html
@@ -8,7 +8,7 @@
     {{ block.super }}
     <style type="text/css">
         {% get_custom_admin_css as css %}
-        {{ css }}
+        {{ css|safe }}
     </style>
 {% endblock %}
 


### PR DESCRIPTION
As the string wasn't marked safe, entities such as `>` got escaped to `&gt;`, messing with the style sheet.