### PR TITLE
Fix menu height.

### DIFF
--- a/admin_menu/sass/admin-menu.scss
+++ b/admin_menu/sass/admin-menu.scss
@@ -32,7 +32,7 @@ body {
 #admin_menu_container {
   background-color: $primary-color;
   padding: 10px 40px 0 40px;
-  height: 40px;
+  min-height: 40px;
 
   .tabs {
     clear: left;


### PR DESCRIPTION

The menu overlaps with the content on a small screnn. The same applies when there are many items on the menu.
Changing from  height:40px to min-height:40px fix the problem